### PR TITLE
add test for loading corrupted header tarr file

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -41,15 +41,15 @@ jobs:
 
   prepare_for_benchmarks:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
       - run: npm install
       - id: set-matrix
         run: |
@@ -92,10 +92,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
       - run: npm install
       - name: Download Benchmark Fixture
         uses: actions/download-artifact@v2

--- a/files.js
+++ b/files.js
@@ -34,11 +34,18 @@ function calculateCRCAndWriteFile(buf, filename, cb) {
 function readFileAndCheckCRC(filename, cb) {
   readFile(filename, (err, buf) => {
     if (err) return cb(err)
+    if (buf.length < 16) return cb(Error('file too short'))
 
-    const crcFile = buf.readUInt32LE(3 * FIELD_SIZE)
-    buf.writeUInt32LE(0, 3 * FIELD_SIZE)
+    let crcFile
+    let crc
+    try {
+      crcFile = buf.readUInt32LE(3 * FIELD_SIZE)
+      buf.writeUInt32LE(0, 3 * FIELD_SIZE)
+      crc = crcCalculate(buf)
+    } catch (err) {
+      return cb(err)
+    }
 
-    const crc = crcCalculate(buf)
     if (crcFile !== 0 && crc !== crcFile) return cb('crc check failed')
     cb(null, buf)
   })

--- a/test/save-load.js
+++ b/test/save-load.js
@@ -138,6 +138,17 @@ test('load non-existing file', (t) => {
   })
 })
 
+test('load corrupted header', (t) => {
+  const filename = path.join(dir, 'corrupted-header.index')
+  const data = new Uint8Array([0, 0, 0, 0, 0, 0])
+  writeFile(filename, data, (err) => {
+    loadTypedArrayFile(filename, Uint32Array, (err, index) => {
+      t.equal(err.message, 'file too short')
+      t.end()
+    })
+  })
+})
+
 test('save and load corrupt bitset', (t) => {
   const idxDir = path.join(dir, 'test-bitset-corrupt')
   mkdirp.sync(idxDir)

--- a/test/save-load.js
+++ b/test/save-load.js
@@ -162,7 +162,7 @@ test('save and load corrupt bitset', (t) => {
       b.writeUInt32LE(123456, 4 * 4)
       writeFile(filename, b, (err) => {
         loadBitsetFile(filename, (err, index) => {
-          t.equal(err, 'crc check failed')
+          t.equal(err.message, 'crc check failed')
           t.end()
         })
       })


### PR DESCRIPTION
**Context:** https://github.com/ssbc/ssb-db2/issues/358

**Problem:** an error is *thrown* from `readFileAndCheckCRC()` when it should be in fact `cb(err)`'d.

**Solution:** catch all errors in that function and call cb(err).

1st :x: 2nd :heavy_check_mark: and then additional commits just add extra checks.