### PR TITLE
ensure only one log.scan at a time

### DIFF
--- a/index.js
+++ b/index.js
@@ -752,10 +752,6 @@ module.exports = function (log, indexesPath) {
     }
   }
 
-  function ensureSeqIndexSync(cb) {
-    ensureIndexSync({ data: { indexName: 'seq' } }, cb)
-  }
-
   function filterIndex(op, filterCheck, cb) {
     if (op.data.indexName === 'sequence') {
       const bitset = new TypedFastBitSet()
@@ -1477,7 +1473,7 @@ module.exports = function (log, indexesPath) {
           recordStream = pull(
             seqStream,
             pull.asyncMap((seq, cb) => {
-              ensureSeqIndexSync(() => {
+              ensureIndexSync({ data: { indexName: 'seq' } }, () => {
                 getRecord(seq, cb)
               })
             })

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jsesc": "^3.0.2",
     "mkdirp": "^1.0.4",
     "multicb": "1.2.2",
+    "mutexify": "^1.4.0",
     "obz": "^1.1.0",
     "promisify-4loc": "1.0.0",
     "pull-async": "~1.0.0",

--- a/test/add.js
+++ b/test/add.js
@@ -165,7 +165,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
 })
 
 prepareAndRunTest('Update index', dir, (t, db, raf) => {
-  t.plan(7)
+  t.plan(5)
   t.timeoutAfter(5000)
   const msg = { type: 'post', text: 'Testing!' }
   let state = validate.initial()
@@ -182,7 +182,7 @@ prepareAndRunTest('Update index', dir, (t, db, raf) => {
     },
   }
 
-  const expectedIndexingActive = [0, 1 /* seq */, 0, 1 /* type_post */, 0]
+  const expectedIndexingActive = [0, 1, 0]
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
     db.all(typeQuery, 0, false, false, 'declared', (err, results) => {

--- a/test/live.js
+++ b/test/live.js
@@ -278,7 +278,7 @@ prepareAndRunTest('Live with initial values', dir, (t, db, raf) => {
 prepareAndRunTest('Live with seq values', dir, (t, db, raf) => {
   let state = validate.initial()
 
-  const n = 1001
+  const n = 11
 
   let a = []
   for (var i = 0; i < n; ++i) {
@@ -380,8 +380,10 @@ prepareAndRunTest('Live with cleanup', dir, (t, db, raf) => {
   )
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
-    addMsg(state.queue[1].value, raf, (err, msg1) => {
-      // console.log("waiting for live query")
-    })
+    setTimeout(() => {
+      addMsg(state.queue[1].value, raf, (err, msg1) => {
+        // console.log("waiting for live query")
+      })
+    }, 100)
   })
 })


### PR DESCRIPTION
## Context

I was experimenting with Manyverse doing deleteFeed-then-compact-then-reindex, and it was odd that post-compaction reindexing lasted 6.5sec while *initial* indexing lasted 4.0sec. 

## Problem

I investigated deeper and the reason was that initial indexing triggers jitdb `createIndexes` which does *one* log scan for *multiple* indexes, but reindexing triggers jitdb `updateIndex` which does one log scan for *each* index.

## Solution

Unify `updateIndex` and `createIndexes` such that both creation and update are performed by the same log.stream. This additionally ensures that jitdb *never* does concurrent log.streams, at any given point in time there is only one jitdb log.stream ongoing.


PS: The git diff is pretty nasty to read, but in reality the new implementation of `updateIndexes()` follows closely the structure of the two old functions.