### PR TITLE
fix pagination nextSeq when there are holes

### DIFF
--- a/operators.js
+++ b/operators.js
@@ -542,11 +542,22 @@ function toPullStream() {
           )
         }
       }
-      if (meta.pageSize || meta.count) {
+
+      if (meta.count) {
         return readable
+      } else if (meta.pageSize) {
+        return pull(
+          readable,
+          pull.filter((page) => page.length > 0)
+        )
       } else {
         // Flatten the "pages" (arrays) into individual messages
-        return pull(readable, pull.map(pull.values), pull.flatten())
+        return pull(
+          readable,
+          pull.filter((page) => page.length > 0),
+          pull.map(pull.values),
+          pull.flatten()
+        )
       }
     }
 

--- a/test/common.js
+++ b/test/common.js
@@ -16,27 +16,26 @@ module.exports = function () {
     return '%' + hash(JSON.stringify(msg, null, 2))
   }
 
-  function addMsg(msg, raf, cb) {
-    var data = {
-      key: getId(msg),
-      value: msg,
+  function addMsg(msgVal, log, cb) {
+    const msg = {
+      key: getId(msgVal),
+      value: msgVal,
       timestamp: Date.now(),
     }
-    var b = Buffer.alloc(bipf.encodingLength(data))
-    bipf.encode(data, b, 0)
-    raf.append(b, function (err, offset) {
+    const buf = bipf.allocAndEncode(msg)
+    log.append(buf, (err, offset) => {
       if (err) cb(err)
       // instead of cluttering the tests with onDrain, we just
       // simulate sync adds here
-      else raf.onDrain(() => cb(null, data, offset))
+      else log.onDrain(() => cb(null, msg, offset))
     })
   }
 
   function addMsgPromise(msg, raf) {
     return new Promise((resolve, reject) => {
-      addMsg(msg, raf, (err, data, offset) => {
+      addMsg(msg, raf, (err, msg, offset) => {
         if (err) reject(err)
-        else resolve({ data, offset })
+        else resolve({ msg, offset })
       })
     })
   }

--- a/test/del.js
+++ b/test/del.js
@@ -2,13 +2,21 @@
 //
 // SPDX-License-Identifier: Unlicense
 
-const test = require('tape')
 const validate = require('ssb-validate')
 const ssbKeys = require('ssb-keys')
 const path = require('path')
-const { prepareAndRunTest, addMsg, helpers } = require('./common')()
+const pify = require('util').promisify
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
+const { prepareAndRunTest, addMsgPromise, helpers } = require('./common')()
+const {
+  fromDB,
+  where,
+  query,
+  slowEqual,
+  paginate,
+  toPullStream,
+} = require('../operators')
 
 const dir = '/tmp/jitdb-add'
 rimraf.sync(dir)
@@ -16,16 +24,16 @@ mkdirp.sync(dir)
 
 var keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 
-prepareAndRunTest('Delete', dir, (t, db, raf) => {
-  const msg1 = { type: 'post', text: 'Testing 1' }
-  const msg2 = { type: 'post', text: 'Testing 2' }
-  const msg3 = { type: 'post', text: 'Testing 3' }
+prepareAndRunTest('delete then index', dir, async (t, jitdb, log) => {
+  const content1 = { type: 'post', text: 'Testing 1' }
+  const content2 = { type: 'post', text: 'Testing 2' }
+  const content3 = { type: 'post', text: 'Testing 3' }
   let state = validate.initial()
-  state = validate.appendNew(state, null, keys, msg1, Date.now())
-  state = validate.appendNew(state, null, keys, msg2, Date.now() + 1)
-  state = validate.appendNew(state, null, keys, msg3, Date.now() + 2)
+  state = validate.appendNew(state, null, keys, content1, Date.now())
+  state = validate.appendNew(state, null, keys, content2, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, content3, Date.now() + 2)
 
-  const typeQuery = {
+  const query = {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
@@ -35,28 +43,132 @@ prepareAndRunTest('Delete', dir, (t, db, raf) => {
     },
   }
 
-  addMsg(state.queue[0].value, raf, (err, msg1) => {
-    addMsg(state.queue[1].value, raf, (err, msg2, offset2) => {
-      addMsg(state.queue[2].value, raf, (err, msg3) => {
-        raf.del(offset2, () => {
-          db.paginate(
-            typeQuery,
-            0,
-            10,
-            false,
-            false,
-            'declared',
-            (err, { results }) => {
-              t.deepEqual(results, [msg1, msg3])
+  const msg1 = (await addMsgPromise(state.queue[0].value, log)).msg
+  const offset2 = (await addMsgPromise(state.queue[1].value, log)).offset
+  const msg3 = (await addMsgPromise(state.queue[2].value, log)).msg
 
-              db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
-                t.deepEqual(results, [msg1, msg3])
-                t.end()
-              })
-            }
-          )
-        })
-      })
-    })
-  })
+  await pify(log.del)(offset2)
+  await pify(log.onDeletesFlushed)()
+
+  const answer = await pify(jitdb.paginate)(
+    query,
+    0,
+    2,
+    false,
+    false,
+    'declared'
+  )
+  t.deepEqual(
+    answer.results.map((msg) => msg.value.content.text),
+    ['Testing 1', 'Testing 3'],
+    'paginate got msg#1 and msg#3'
+  )
+
+  const results = await pify(jitdb.all)(query, 0, false, false, 'declared')
+  t.deepEqual(
+    results.map((msg) => msg.value.content.text),
+    ['Testing 1', 'Testing 3'],
+    'all got msg#1 and msg#3'
+  )
+})
+
+prepareAndRunTest('index then delete', dir, async (t, jitdb, log) => {
+  const content1 = { type: 'post', text: 'Testing 1' }
+  const content2 = { type: 'post', text: 'Testing 2' }
+  const content3 = { type: 'post', text: 'Testing 3' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, keys, content1, Date.now())
+  state = validate.appendNew(state, null, keys, content2, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, content3, Date.now() + 2)
+
+  const query = {
+    type: 'EQUAL',
+    data: {
+      seek: helpers.seekType,
+      value: helpers.toBipf('post'),
+      indexType: 'type',
+      indexName: 'type_post',
+    },
+  }
+
+  const msg1 = (await addMsgPromise(state.queue[0].value, log)).msg
+  const offset2 = (await addMsgPromise(state.queue[1].value, log)).offset
+  const msg3 = (await addMsgPromise(state.queue[2].value, log)).msg
+
+  await pify(jitdb.prepare)(query)
+
+  await pify(log.del)(offset2)
+  await pify(log.onDeletesFlushed)()
+
+  const answer = await pify(jitdb.paginate)(
+    query,
+    0,
+    2,
+    false,
+    false,
+    'declared'
+  )
+  t.deepEqual(
+    answer.results.map((msg) => msg.value.content.text),
+    ['Testing 1'],
+    'paginate got msg#1'
+  )
+
+  const answer2 = await pify(jitdb.paginate)(
+    query,
+    answer.nextSeq,
+    2,
+    false,
+    false,
+    'declared'
+  )
+  t.deepEqual(
+    answer2.results.map((msg) => msg.value.content.text),
+    ['Testing 3'],
+    'paginate got msg#3'
+  )
+
+  const results = await pify(jitdb.all)(query, 0, false, false, 'declared')
+  t.deepEqual(
+    results.map((msg) => msg.value.content.text),
+    ['Testing 1', 'Testing 3'],
+    'all got msg#1 and msg#3'
+  )
+})
+
+prepareAndRunTest('index then delete many', dir, async (t, jitdb, log) => {
+  const content1 = { type: 'post', text: 'Testing 1' }
+  const content2 = { type: 'post', text: 'Testing 2' }
+  const content3 = { type: 'post', text: 'Testing 3' }
+  const content4 = { type: 'post', text: 'Testing 4' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, keys, content1, Date.now())
+  state = validate.appendNew(state, null, keys, content2, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, content3, Date.now() + 2)
+  state = validate.appendNew(state, null, keys, content4, Date.now() + 2)
+
+  const offset1 = (await addMsgPromise(state.queue[0].value, log)).offset
+  const offset2 = (await addMsgPromise(state.queue[1].value, log)).offset
+  const msg3 = (await addMsgPromise(state.queue[2].value, log)).msg
+  const msg4 = (await addMsgPromise(state.queue[3].value, log)).msg
+
+  await pify(jitdb.prepare)(slowEqual('value.content.type', 'post'))
+
+  await pify(log.del)(offset1)
+  await pify(log.del)(offset2)
+  await pify(log.onDeletesFlushed)()
+
+  const source = query(
+    fromDB(jitdb),
+    where(slowEqual('value.content.type', 'post')),
+    paginate(2),
+    toPullStream()
+  )
+
+  const page1 = await pify(source)(null)
+  t.deepEqual(
+    page1.map((msg) => msg.value.content.text),
+    ['Testing 3', 'Testing 4'],
+    'non-empty page 1'
+  )
 })


### PR DESCRIPTION
Fixes (somewhat) issue #223.

`jitdb.paginate`'s "nextSeq" calculation is improved now, by looking at all the seqs, not at the non-deleted records (this would have cause the same "page" to be scanned a few times, resulting in duplicates).

And now `toPullStream()` can emit pages that are smaller than the requested page size, but it will never emit pages of size zero, we pull.filter those out.