### PR TITLE
keep state file to signal reindex post-compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ First some terminology: offset refers to the byte position in the log
 of a message. Seq refers to the 0-based position of a message in the
 log.
 
-### paginate(operation, seq, limit, descending, onlyOffset, sortBy, cb)
+### paginate(operation, seq, limit, descending, onlyOffset, sortBy, latestMsgKeyPrecompaction, cb)
 
 Query the database returning paginated results. If one or more indexes
 doesn't exist or are outdated, the indexes will be updated before the
@@ -498,6 +498,9 @@ refers to the timestamp for when a message was created, while
 `arrival` refers to when a message was added to the database. This can
 be important for messages from other peers that might arrive out of
 order compared when they were created.
+
+`latestMsgKeyPrecompaction` is used internally, and it's safe to just pass
+`null` as its value when you're calling `paginate`.
 
 The result is an object with the fields:
 

--- a/files.js
+++ b/files.js
@@ -238,7 +238,7 @@ const EmptyFile = {
 
   delete(filename, cb) {
     EmptyFile.exists(filename, (err, exists) => {
-      if (cb) return cb(err)
+      if (err) return cb(err)
       if (!exists) cb(null)
       else EmptyFile._actuallyDelete(filename, cb)
     })

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ module.exports = function (log, indexesPath) {
       function conclude() {
         EmptyFile.delete(postCompactReindexPath, () => {
           if (waitingCompaction.length === 0) return
-          for (const cb of waitingCompaction) cb(stats.holesFound)
+          for (const cb of waitingCompaction) cb()
           waitingCompaction.length = 0
         })
       }
@@ -1321,13 +1321,13 @@ module.exports = function (log, indexesPath) {
     descending,
     onlyOffset,
     sortBy,
-    latestMsgKey,
+    latestMsgKeyPrecompaction,
     cb
   ) {
     if (!log.compactionProgress.value.done) {
       waitingCompaction.push(() => {
-        if (latestMsgKey) {
-          findSeqForMsgKey(latestMsgKey, (err, seqForMsgKey) => {
+        if (latestMsgKeyPrecompaction) {
+          findSeqForMsgKey(latestMsgKeyPrecompaction, (err, seqForMsgKey) => {
             if (err) return cb(err)
             const resumeSeq = seqForMsgKey + 1
             // prettier-ignore

--- a/index.js
+++ b/index.js
@@ -234,7 +234,6 @@ module.exports = function (log, indexesPath) {
   }
 
   function saveIndex(name, index, count, cb) {
-    debug('saving index: %s', name)
     if (index.prefix && index.map) savePrefixMapIndex(name, index, count, cb)
     else if (index.prefix) savePrefixIndex(name, index, count, cb)
     else saveBitsetIndex(name, index, cb)
@@ -278,7 +277,7 @@ module.exports = function (log, indexesPath) {
   }
 
   function growTarrIndex(index, Type) {
-    debug('growing index')
+    debug('growing index %s', index.name)
     const newArray = new Type(index.tarr.length * 2)
     newArray.set(index.tarr)
     index.tarr = newArray
@@ -623,7 +622,7 @@ module.exports = function (log, indexesPath) {
 
       const logstreamId = Math.ceil(Math.random() * 1000)
       // prettier-ignore
-      debug(`log.stream #${logstreamId} started, updating indexes ${oldIndexNames.concat(newIndexNames).join('|')}`)
+      debug(`log.stream #${logstreamId} started, updating indexes ${oldIndexNames.concat(newIndexNames).join('|')} from offset ${latestOffset}`)
       status.update(indexes, indexNamesForStatus)
       status.update(newIndexes, newIndexNames)
       indexingActive.set(indexingActive.value + 1)
@@ -774,7 +773,6 @@ module.exports = function (log, indexesPath) {
     if (log.since.value > index.offset || op.data.version > index.version) {
       updateIndexes([op], cb)
     } else {
-      debug('ensureIndexSync %s is already synced', op.data.indexName)
       cb()
     }
   }

--- a/operators.js
+++ b/operators.js
@@ -516,6 +516,7 @@ function toPullStream() {
       let total = Infinity
       const limit = meta.pageSize || meta.batchSize || 20
       let shouldEnd = false
+      let latestMsgKey = null
       function readable(end, cb) {
         if (end) return cb(end)
         if (seq >= total || shouldEnd) return cb(true)
@@ -530,12 +531,16 @@ function toPullStream() {
             meta.descending,
             meta.asOffsets,
             meta.sortBy,
+            latestMsgKey,
             (err, answer) => {
               if (err) return cb(err)
               else if (answer.total === 0) cb(true)
               else {
                 total = answer.total
                 seq = answer.nextSeq
+                if (answer.results.length > 0) {
+                  latestMsgKey = answer.results[answer.results.length - 1].key
+                }
                 cb(null, answer.results)
               }
             }

--- a/operators.js
+++ b/operators.js
@@ -494,6 +494,7 @@ function toCallback(cb) {
           descending,
           asOffsets,
           sortBy,
+          null,
           cb
         )
       else meta.jitdb.all(ops, seq, descending, asOffsets, sortBy, cb)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "!example.js"
   ],
   "dependencies": {
-    "atomic-file-rw": "^0.2.1",
+    "atomic-file-rw": "^0.3.0",
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.6.2",
     "crc": "3.6.0",
@@ -33,16 +33,17 @@
     "pull-stream": "^3.6.14",
     "push-stream": "^11.0.0",
     "push-stream-to-pull-stream": "^1.0.3",
+    "rimraf": "^3.0.2",
     "sanitize-filename": "^1.6.3",
     "traverse": "^0.6.6",
     "typedarray-to-buffer": "^4.0.0",
     "typedfastbitset": "~0.2.1"
   },
   "peerDependencies": {
-    "async-append-only-log": "^4.2.1"
+    "async-append-only-log": "^4.3.2"
   },
   "devDependencies": {
-    "async-append-only-log": "^4.3.1",
+    "async-append-only-log": "^4.3.2",
     "expose-gc": "^1.0.0",
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
@@ -53,7 +54,6 @@
     "pretty-bytes": "^5.6.0",
     "pretty-quick": "^3.1.0",
     "pull-pushable": "^2.2.0",
-    "rimraf": "^3.0.2",
     "ssb-fixtures": "2.2.0",
     "ssb-keys": "^8.1.0",
     "ssb-ref": "^2.14.3",

--- a/test/add.js
+++ b/test/add.js
@@ -45,6 +45,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
         false,
         false,
         'declared',
+        null,
         (err, { results }) => {
           t.equal(results.length, 2)
 
@@ -56,6 +57,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
             true,
             false,
             'declared',
+            null,
             (err, { results }) => {
               t.equal(results.length, 2)
               t.equal(results[0].value.author, keys2.id)
@@ -67,6 +69,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                 false,
                 false,
                 'declared',
+                null,
                 (err, { results }) => {
                   t.equal(results.length, 2)
                   t.equal(results[0].value.author, keys.id)
@@ -87,6 +90,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                     false,
                     false,
                     'declared',
+                    null,
                     (err, { results }) => {
                       t.equal(results.length, 1)
                       t.equal(results[0].id, msg1.id)
@@ -99,6 +103,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                         false,
                         false,
                         'declared',
+                        null,
                         (err, { results }) => {
                           t.equal(results.length, 1)
                           t.equal(results[0].id, msg1.id)
@@ -113,6 +118,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                             false,
                             false,
                             'declared',
+                            null,
                             (err, { results }) => {
                               t.equal(results.length, 1)
                               t.equal(results[0].id, msg1.id)
@@ -143,6 +149,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                                 false,
                                 false,
                                 'declared',
+                                null,
                                 (err, { results }) => {
                                   t.equal(results.length, 2)
                                   t.end()
@@ -233,6 +240,7 @@ prepareAndRunTest('grow', dir, (t, db, raf) => {
         false,
         false,
         'declared',
+        null,
         (err, { results }) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing 31999')

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -43,16 +43,6 @@ prepareAndRunTest('toPullStream post-compact', dir, async (t, jitdb, log) => {
   state = validate.appendNew(state, null, keys, content6, Date.now() + 6)
   state = validate.appendNew(state, null, keys, content7, Date.now() + 7)
 
-  const typeQuery = {
-    type: 'EQUAL',
-    data: {
-      seek: helpers.seekType,
-      value: helpers.toBipf('post'),
-      indexType: 'type',
-      indexName: 'type_post',
-    },
-  }
-
   const offset0 = (await addMsgPromise(state.queue[0].value, log)).offset
   const offset1 = (await addMsgPromise(state.queue[1].value, log)).offset
   const offset2 = (await addMsgPromise(state.queue[2].value, log)).offset
@@ -93,6 +83,80 @@ prepareAndRunTest('toPullStream post-compact', dir, async (t, jitdb, log) => {
           t.equals(msgs[0].value.content.text, 'Testing 5', 'msg 5')
           t.equals(msgs[1].value.content.text, 'Testing 6', 'msg 6')
           t.equals(msgs[2].value.content.text, 'Testing 7', 'msg 7')
+          queryEnded = true
+        })
+        return false // abort listening to compaction progress
+      }
+    })
+
+    log.compact((err) => {
+      if (err) t.fail(err)
+      resolve()
+    })
+  })
+
+  t.true(queryEnded, 'query ended')
+})
+
+prepareAndRunTest('toPullStream post-compact 2', dir, async (t, jitdb, log) => {
+  const content0 = { type: 'post', text: 'Testing 0' }
+  const content1 = { type: 'post', text: 'Testing 1' }
+  const content2 = { type: 'post', text: 'Testing 2' }
+  const content3 = { type: 'post', text: 'Testing 3' }
+  const content4 = { type: 'post', text: 'Testing 4' }
+  const content5 = { type: 'post', text: 'Testing 5' }
+  const content6 = { type: 'post', text: 'Testing 6' }
+  const content7 = { type: 'post', text: 'Testing 7' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, keys, content0, Date.now())
+  state = validate.appendNew(state, null, keys, content1, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, content2, Date.now() + 2)
+  state = validate.appendNew(state, null, keys, content3, Date.now() + 3)
+  state = validate.appendNew(state, null, keys, content4, Date.now() + 4)
+  state = validate.appendNew(state, null, keys, content5, Date.now() + 5)
+  state = validate.appendNew(state, null, keys, content6, Date.now() + 6)
+  state = validate.appendNew(state, null, keys, content7, Date.now() + 7)
+
+  const offset0 = (await addMsgPromise(state.queue[0].value, log)).offset
+  const offset1 = (await addMsgPromise(state.queue[1].value, log)).offset
+  const offset2 = (await addMsgPromise(state.queue[2].value, log)).offset
+  const offset3 = (await addMsgPromise(state.queue[3].value, log)).offset
+  const offset4 = (await addMsgPromise(state.queue[4].value, log)).offset
+  const offset5 = (await addMsgPromise(state.queue[5].value, log)).offset
+  const offset6 = (await addMsgPromise(state.queue[6].value, log)).offset
+  const offset7 = (await addMsgPromise(state.queue[7].value, log)).offset
+
+  await pify(jitdb.prepare)(slowEqual('value.content.type', 'post'))
+
+  await pify(log.del)(offset1)
+  t.pass('delete msg 1')
+  await pify(log.del)(offset2)
+  t.pass('delete msg 2')
+  await pify(log.onDeletesFlushed)()
+
+  const source = query(
+    fromDB(jitdb),
+    where(slowEqual('value.content.type', 'post')),
+    paginate(3),
+    toPullStream()
+  )
+
+  const msgs = await pify(source)(null)
+  t.equals(msgs.length, 1, '1st page has 1 message')
+  t.equals(msgs[0].value.content.text, 'Testing 0', 'msg 0')
+
+  let queryStarted = false
+  let queryEnded = false
+  await new Promise((resolve) => {
+    log.compactionProgress((stats) => {
+      if (!stats.done && !queryStarted) {
+        queryStarted = true
+        source(null, (err, msgs) => {
+          t.error(err, 'no error')
+          t.equals(msgs.length, 3, '2nd page has 3 messages')
+          t.equals(msgs[0].value.content.text, 'Testing 3', 'msg 3')
+          t.equals(msgs[1].value.content.text, 'Testing 4', 'msg 4')
+          t.equals(msgs[2].value.content.text, 'Testing 5', 'msg 5')
           queryEnded = true
         })
         return false // abort listening to compaction progress

--- a/test/del.js
+++ b/test/del.js
@@ -56,7 +56,8 @@ prepareAndRunTest('delete then index', dir, async (t, jitdb, log) => {
     2,
     false,
     false,
-    'declared'
+    'declared',
+    null
   )
   t.deepEqual(
     answer.results.map((msg) => msg.value.content.text),
@@ -106,7 +107,8 @@ prepareAndRunTest('index then delete', dir, async (t, jitdb, log) => {
     2,
     false,
     false,
-    'declared'
+    'declared',
+    null
   )
   t.deepEqual(
     answer.results.map((msg) => msg.value.content.text),
@@ -120,7 +122,8 @@ prepareAndRunTest('index then delete', dir, async (t, jitdb, log) => {
     2,
     false,
     false,
-    'declared'
+    'declared',
+    null
   )
   t.deepEqual(
     answer2.results.map((msg) => msg.value.content.text),

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -517,6 +517,7 @@ prepareAndRunTest('Prefix delete', dir, (t, db, raf) => {
                 false,
                 false,
                 'declared',
+                null,
                 (err, answer) => {
                   t.equal(answer.results.length, 1)
                   t.equal(answer.results[0].value.content.text, 'Testing 2!')

--- a/test/query.js
+++ b/test/query.js
@@ -98,6 +98,7 @@ prepareAndRunTest('Top 1 multiple types', dir, (t, db, raf) => {
           true,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing 2!')
@@ -133,6 +134,7 @@ prepareAndRunTest('Limit -1', dir, (t, db, raf) => {
       true,
       false,
       'declared',
+      null,
       (err2, { results }) => {
         t.error(err2)
         t.equal(results.length, 0)
@@ -166,6 +168,7 @@ prepareAndRunTest('Limit 0', dir, (t, db, raf) => {
       true,
       false,
       'declared',
+      null,
       (err2, { results }) => {
         t.error(err2)
         t.equal(results.length, 0)
@@ -288,6 +291,7 @@ prepareAndRunTest('Paginate many pages', dir, (t, db, raf) => {
           false,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, '1st')
@@ -298,6 +302,7 @@ prepareAndRunTest('Paginate many pages', dir, (t, db, raf) => {
               false,
               false,
               'declared',
+              null,
               (err, { results }) => {
                 t.equal(results.length, 1)
                 t.equal(results[0].value.content.text, '2nd')
@@ -308,6 +313,7 @@ prepareAndRunTest('Paginate many pages', dir, (t, db, raf) => {
                   false,
                   false,
                   'declared',
+                  null,
                   (err, { results }) => {
                     t.equal(results.length, 1)
                     t.equal(results[0].value.content.text, '3rd')
@@ -350,6 +356,7 @@ prepareAndRunTest('Paginate empty', dir, (t, db, raf) => {
         false,
         false,
         'declared',
+        null,
         (err3, { results }) => {
           t.error(err3)
           t.equal(results.length, 0)
@@ -390,6 +397,7 @@ prepareAndRunTest('Seq', dir, (t, db, raf) => {
           true,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing!')
@@ -425,6 +433,7 @@ prepareAndRunTest('Buffer', dir, (t, db, raf) => {
       true,
       false,
       'declared',
+      null,
       (err, { results }) => {
         t.equal(results.length, 1)
         t.equal(results[0].value.content.text, 'Testing!')
@@ -464,6 +473,7 @@ prepareAndRunTest('Undefined', dir, (t, db, raf) => {
           false,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 2)
             t.equal(results[0].value.content.text, 'Testing no root')
@@ -506,6 +516,7 @@ prepareAndRunTest('Null', dir, (t, db, raf) => {
           false,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing root null')
@@ -702,6 +713,7 @@ prepareAndRunTest('Data offsets', dir, (t, db, raf) => {
           true,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing no root')
@@ -781,6 +793,7 @@ prepareAndRunTest('Data seqs', dir, (t, db, raf) => {
           true,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing no root')


### PR DESCRIPTION
This PR solves 3 problems:

- Issue #226
- `reindex` was wrong for bitset indexes
- Keeping track of when should `reindex()` be called post-compact should be a jitdb concern
  - (Currently ssb-db2 persists three state files for this, one of them for jitdb reindexing)

These changes should cause a **breaking change** (because of the added argument in `paginate()`) and we should also remove the ssb-db2 `post-compact-reindex-jit` state file.