### PR TITLE
handle deletes in findSeqForMsgKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -1294,6 +1294,10 @@ module.exports = function (log, indexesPath) {
     log.stream({ offsets: false, values: true, decrypt: false }).pipe(
       push.drain(
         function sinkToFindSeq(buffer) {
+          if (!buffer) {
+            seq += 1
+            return
+          }
           const pKey = bipf.seekKey2(buffer, 0, BIPF_KEY, 0)
           const msgKeyCandidate = bipf.decode(buffer, pKey)
           if (msgKeyCandidate === msgKey) {


### PR DESCRIPTION
## Problem

Right after compaction ends, we can resume pulling some pull-streams, and for that, we will use `findSeqForMsgKey`, **but** after compaction ends **another** thing that is now allowed to run is `log.del`.

So `findSeqForMsgKey` could theoretically stumble upon a delete.

## Solution

My first reaction is that this problem is hairy, because we thought that `findSeqForMsgKey` can safely assume there are no deletes. However, there are two possible cases:

1. The deleted records are not the record we are looking for, so scanning through them is harmless
2. The record we are looking for was deleted

(1) is harmless, so we're good.

(2) is actually not that bad, we can just return the error (which is what this PR will do in that case) which will bubble up as a pull-stream "pull" error. This should be rare.

So the solution in this PR is to just skip deleted records if we stumble upon them.

## Discussion

(2) sounds like we still have a big problem, and the scanning of the log seems like it sucks, **but** we would also have this problem if we were using ssb-db2 `keys` index, because given a `msgKey`, you're not guaranteed to find it in `keys` index if that `msgKey` has just been deleted!

For now I'm fine with accepting this risk and seeing what happens in production. The worst that would happen is a runtime crash which doesn't repeat once you restart the app. We will get those crash reports and we'll know how often this problem happens.

To "properly" solve this problem, I was thinking that AAOL compaction could produce a "mapping" (maybe as a bitset or some other highly compressed typed array) that tells us the *whole* "diff" between old seqs and new seqs, and then given any old seq we can mathematically determine the new seq. Maybe that would work.