### PR TITLE
fix paginate on prefix index false positives

### DIFF
--- a/index.js
+++ b/index.js
@@ -1241,7 +1241,8 @@ module.exports = function (log, indexesPath) {
         }),
         push.filter((x) => (onlyOffset ? true : x)), // removes deleted messages
         push.collect((err, results) => {
-          cb(err, { results, total, nextSeq: seq + seqs.length })
+          const more = seqs.length || limit
+          cb(err, { results, total, nextSeq: seq + more })
         })
       )
     }


### PR DESCRIPTION
## Context

I was updating ssb-db2 in some other libraries and noticed an infinite loop somewhere in the stack and it was in jitdb, related to pagination.

## Problem

Reminder: we used to increment `seq` with the `limit` that defines the page size, then we changed that to be `seqs.length`.

If you're using a prefix index, the initial `seqs` may contain false positives, which are then removed in the "filters". So then the `seqs.length` turns out to be zero. Since the calculation of `nextSeq` was `seq + seqs.length`, this meant that the same `seq` got repeated over and over again, infinitely.

## Solution

If `seqs.length` is zero, we fallback to using `limit` as the next page size.

1st :x: 2nd :heavy_check_mark: 