### PR TITLE
optimize reindex() when seq is zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -1597,11 +1597,15 @@ module.exports = function (log, indexesPath) {
         if (index.map) {
           // prefix map pushes to arrays, so we need to clean up
           for (let [prefix, arr] of Object.entries(index.map)) {
-            index.map[prefix] = arr.filter((x) => x < seq)
+            if (seq === 0) index.map[prefix].length = 0
+            else index.map[prefix] = arr.filter((x) => x < seq)
           }
         }
 
-        if (index.bitset) index.bitset.removeRange(seq, Infinity)
+        if (index.bitset) {
+          if (seq === 0) index.bitset.clear()
+          else index.bitset.removeRange(seq, Infinity)
+        }
 
         index.offset = prevOffset
       }

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -187,7 +187,14 @@ prepareAndRunTest('reindex prefix map', dir, (t, db, raf) => {
         removeFilter()
         db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
           t.equal(results.length, 2)
-          t.end()
+
+          const secondMsgOffset = 352
+          db.reindex(secondMsgOffset, () => {
+            db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+              t.equal(results.length, 2)
+              t.end()
+            })
+          })
         })
       })
     })


### PR DESCRIPTION
Just a neat optimization I stumbled upon.