### PR TITLE
live queries should be aware of deleted records

### DIFF
--- a/index.js
+++ b/index.js
@@ -1080,6 +1080,7 @@ module.exports = function (log, indexesPath) {
   }
 
   function isValueOk(ops, value, isOr) {
+    if (!value) return false
     const pValue = bipf.seekKey2(value, 0, BIPF_VALUE, 0)
 
     for (let i = 0; i < ops.length; ++i) {


### PR DESCRIPTION
## Context

There's a [crash in Manyverse](https://gitlab.com/staltz/manyverse/-/issues/2054) with this stack trace:

```
TypeError: Cannot read property '0' of null
    at Object.read [as decode] (/data/data/se.manyver/files/nodejs-project/index.js:95407:14)
    at Object.seekKey2 (/data/data/se.manyver/files/nodejs-project/index.js:48349:24)
    at isValueOk (/data/data/se.manyver/files/nodejs-project/index.js:34315:25)
    at /data/data/se.manyver/files/nodejs-project/index.js:34797:31
    at /data/data/se.manyver/files/nodejs-project/index.js:75597:23
    at /data/data/se.manyver/files/nodejs-project/index.js:72339:16
    at /data/data/se.manyver/files/nodejs-project/index.js:37966:7
    at /data/data/se.manyver/files/nodejs-project/index.js:90290:5
    at /data/data/se.manyver/files/nodejs-project/index.js:32394:9
    at /data/data/se.manyver/files/nodejs-project/index.js:90295:5
```

From top to bottom, that's:

- fast-varint
- bipf
- jitdb
- ...

## Problem

Live streams in jitdb are bumping into deleted records. I'm not sure why, but they are. 

This is from Manyverse 0.2208.5 which was [using jitdb@7.0.2](https://github.com/staltz/manyverse/blob/663fe9e0d08740a81d79b0cc330613a29465252f/src/backend/package-lock.json#L2355), [ssb-db2@4.2.1](https://github.com/staltz/manyverse/blob/663fe9e0d08740a81d79b0cc330613a29465252f/src/backend/package-lock.json#L5408), and [AAOL@4.3.6](https://github.com/staltz/manyverse/blob/663fe9e0d08740a81d79b0cc330613a29465252f/src/backend/package-lock.json#L275). This might have changed in the newest version of Manyverse that's using AAOL@4.3.7 which fixed live streams post-compaction.

Anyway, seems reasonable that we have to treat `null` records from live streams.

## Solution

`isValueOk` returns false if the record is deleted.