### PR TITLE
fix off-by-one error when saving index count

### DIFF
--- a/index.js
+++ b/index.js
@@ -345,6 +345,7 @@ module.exports = function (log, indexesPath) {
   function getSeqFromOffset(offset) {
     if (offset === -1) return -1
     const { tarr, count } = seqIndex
+    if (tarr[count - 1] === offset) return count - 1
     const seq = bsb.eq(tarr, offset, 0, count - 1)
     if (seq < 0) return 0
     return seq
@@ -676,7 +677,7 @@ module.exports = function (log, indexesPath) {
             const now = Date.now()
             if (now - lastSaved >= 60e3) {
               lastSaved = now
-              save(seq, offset, false)
+              save(seq + 1, offset, false)
             }
           }
 


### PR DESCRIPTION
## Context

https://github.com/ssbc/jitdb/issues/234

## Problem

We have an off-by-one mistake in the usage of the `save(count, offset, done)` function in `updateIndexes()`.

The first argument is `count` but we passed `seq` to it, while the intention was to pass `seq + 1`, because **seq is zero-based**, it's used to pick items from the `tarr` array.

When the log stream ends, we call `save()` correctly, but when we call `save()` every 1min *during* the log stream, we passed the wrong value. In Manyverse, this meant that while indexing was in-progress, the intermediate saved states were not correct, they only got correct when the log stream ended. So if the app crashed in the middle, it would start from the wrong point on the next app startup.

Before this PR, the `getSeqFromOffsets` would give the wrong value, but it was doing a binary search from positions `0` to `count - 1` in the `tarr`, while the correct value was actually at position `count`. So this meant that `getSeqFromOffsets` returned seq `0`, and this would then create a disalignment between "seqs" and "offsets" on other indexes.

I have a strong suspicion that this is *THE* indexing bug that we've been trying to hunt down for months/years now, because this bug [has been here since jitdb@2.3.3](https://github.com/ssbc/jitdb/blob/4f3104b685c47d9b529a8123405fd71d8fc098cf/index.js#L495), which is the version of jitdb we used in Manyverse the first time we put ssb-db2 in.

## Solution

Make sure that `save()`'s first argument is always semantically the "count".