### PR TITLE
replace push.collect with push.drain

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ module.exports = function (log, indexesPath) {
             cb()
           } else cb()
         }),
-        push.collect(cb)
+        push.drain(null, cb)
       )
     })
   }
@@ -1047,7 +1047,7 @@ module.exports = function (log, indexesPath) {
         push(
           push.values(lazyIdxNames),
           push.asyncMap(loadLazyIndex),
-          push.collect(next)
+          push.drain(null, next)
         )
       }),
 
@@ -1634,7 +1634,7 @@ module.exports = function (log, indexesPath) {
           cb()
         }
       }),
-      push.collect((err) => {
+      push.drain(null, (err) => {
         if (err) return cb(err)
 
         clearCache()

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pull-awaitable": "^1.0.0",
     "pull-cat": "~1.1.11",
     "pull-stream": "^3.6.14",
-    "push-stream": "^11.0.0",
+    "push-stream": "^11.2.0",
     "push-stream-to-pull-stream": "^1.0.3",
     "rimraf": "^3.0.2",
     "sanitize-filename": "^1.6.3",


### PR DESCRIPTION
**Problem:** `push.collect` accumulates an array of all results, but we don't actually need or use those results, while this could be a source of memory consumption that could contribute to out-of-memory crashes.

**Solution:** use `push.drain` instead.