### PR TITLE
Offset operator should work a copy of input data

### DIFF
--- a/operators.js
+++ b/operators.js
@@ -319,7 +319,7 @@ function liveSeqs(pullStream) {
 function offsets(values) {
   return {
     type: 'OFFSETS',
-    offsets: values,
+    offsets: values.slice(0),
   }
 }
 


### PR DESCRIPTION
I wonder if this is similar to what you were seeing the other day @staltz 

I was debugging https://github.com/ssbc/ssb-tribes2/issues/48 and ran into the following trace:

```
 exec operation [
      {
        meta: { jitdb: [Object], db: [Object], asOffsets: true, batchSize: 1000 }
      },
      {
        type: 'OFFSETS',
        offsets: [ 5817, 10965, 12140 ],
        meta: { jitdb: [Object], db: [Object], asOffsets: true, batchSize: 1000 }
      }
    ] AND
    exec operation 2 [
      {
        meta: { jitdb: [Object], db: [Object], asOffsets: true, batchSize: 1000 }
      },
      {
        type: 'OFFSETS',
        offsets: [ 5817, 10965, 12140 ],
        meta: { jitdb: [Object], db: [Object], asOffsets: true, batchSize: 1000 }
      }
    ] AND
    exec operation 2.5 [ { data: { indexName: 'seq' } } ]
    not updating index with 10965
    removing again box2 10965
    not updating index with 12140
    removing again box2 12140
    exec operation 3 [
      {
        meta: { jitdb: [Object], db: [Object], asOffsets: true, batchSize: 1000 }
      },
      {
        type: 'OFFSETS',
        offsets: [ 5817 ],
        meta: { jitdb: [Object], db: [Object], asOffsets: true, batchSize: 1000 }
      }
    ] AND
```

So what happens is that we add 2 new values to the database. Those are not indexed yet, we then run reindexencrypted in db2 which in turn calls jitdb with the offsets that should be checked. Jitdb then figures out that seq needs to be updated, this calls log.get which decrypts the messages and *removes* them from the offsets (coming from private index). And because we are working on values by reference after seq index is updated the offsets doesn't include the 2 new messages and thus reindexvalues are never triggered for the 2 new values. There might be other cases where might need something similar, but at least this fixes a real problem.