### PR TITLE
ignore DEFERRED ops in prepare()

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ module.exports = function (log, indexesPath) {
   let timestampIndex
   let sequenceIndex
   let isReady = false
-  let jitdb
   const waitingReady = new Set()
   let compacting = false
   let compactStartOffset = null
@@ -1649,7 +1648,7 @@ module.exports = function (log, indexesPath) {
     )
   }
 
-  jitdb = {
+  return {
     onReady,
     paginate,
     all,
@@ -1665,5 +1664,4 @@ module.exports = function (log, indexesPath) {
     // testing
     indexes,
   }
-  return jitdb
 }

--- a/test/add.js
+++ b/test/add.js
@@ -432,7 +432,6 @@ prepareAndRunTest('prepare a DEFERRED operation', dir, (t, db, raf) => {
   db.prepare(deferredQuery, (err, duration) => {
     t.error(err, 'no error')
     t.equals(typeof duration, 'number')
-    t.ok(duration)
     t.end()
   })
 })

--- a/test/add.js
+++ b/test/add.js
@@ -422,11 +422,9 @@ prepareAndRunTest('prepare an index', dir, (t, db, raf) => {
 })
 
 prepareAndRunTest('prepare a DEFERRED operation', dir, (t, db, raf) => {
-  let deferredCalled = false
   const deferredQuery = {
     type: 'DEFERRED',
     task: (meta, cb) => {
-      deferredCalled = true
       cb()
     },
   }
@@ -435,7 +433,6 @@ prepareAndRunTest('prepare a DEFERRED operation', dir, (t, db, raf) => {
     t.error(err, 'no error')
     t.equals(typeof duration, 'number')
     t.ok(duration)
-    t.true(deferredCalled)
     t.end()
   })
 })

--- a/test/add.js
+++ b/test/add.js
@@ -420,3 +420,22 @@ prepareAndRunTest('prepare an index', dir, (t, db, raf) => {
     })
   )
 })
+
+prepareAndRunTest('prepare a DEFERRED operation', dir, (t, db, raf) => {
+  let deferredCalled = false
+  const deferredQuery = {
+    type: 'DEFERRED',
+    task: (meta, cb) => {
+      deferredCalled = true
+      cb()
+    },
+  }
+
+  db.prepare(deferredQuery, (err, duration) => {
+    t.error(err, 'no error')
+    t.equals(typeof duration, 'number')
+    t.ok(duration)
+    t.true(deferredCalled)
+    t.end()
+  })
+})


### PR DESCRIPTION
## Context

In Manyverse I use `jitdb.prepare()` to warm up all the jit indexes, and I recently added `prepare` on `isPrivate('box')`:

https://github.com/staltz/manyverse/blob/781f6066e4fdfa3451b8c9ce48b4235d0374b8e3/src/backend/plugins/dbUtils.ts#L195

Which in ssb-db2 may use a `deferred`:

https://github.com/ssbc/ssb-db2/blob/289e00a964be367c882accb0a131576136c5b602/operators/index.js#L181-L197

## Problem

In jitdb, we only resolve/execute the `DEFERRED` tasks in `operators.js` and if the developer uses either `toCallback()` or `toPullStream()`. But when using `prepare()`, we actually don't use `toCallback()` nor `toPullStream()`. This means that the `DEFERRED` operation ends up in `executeOperation` and bumps into this line:

https://github.com/ssbc/jitdb/blob/3bb1da79e52f60567f3d42f92ab4772023ad7171/index.js#L994

This doesn't cause a crash or any stressful problem, but it causes a `console.error` that may be annoying.

## Solution

If we have a `DEFERRED` in our `prepare()` then just execute the deferred operation.